### PR TITLE
dynamic can read numpy matrix as the feature matrix

### DIFF
--- a/pydlm/modeler/dynamic.py
+++ b/pydlm/modeler/dynamic.py
@@ -16,6 +16,7 @@ The name dynamic means that the features are changing over time.
 """
 import numpy as np
 from collections import MutableSequence
+from copy import deepcopy
 
 import pydlm.base.tools as tl
 from .component import component
@@ -72,7 +73,9 @@ class dynamic(component):
             raise NameError("The current version does not support missing data" +
                             "in the features.")
 
-        self.features = tl.duplicateList(features)
+        self.features = deepcopy(features)
+        if isinstance(features, np.matrix):
+            self.features = self.features.tolist()
         self.componentType = 'dynamic'
         self.name = name
         self.discount = np.ones(self.d) * discount

--- a/pydlm/tests/modeler/testDynamic.py
+++ b/pydlm/tests/modeler/testDynamic.py
@@ -9,6 +9,10 @@ class testDynamic(unittest.TestCase):
         self.features = np.matrix(np.random.rand(10, 2)).tolist()
         self.newDynamic = dynamic(features=self.features, w=1.0)
 
+    def testInputNumpyMatrix(self):
+        dynamic(features=np.random.rand(10, 2), w=1.0)
+        pass
+
     def testInitialization(self):
         self.assertEqual(self.newDynamic.d, 2)
         self.assertEqual(self.newDynamic.n, 10)


### PR DESCRIPTION
@xgdgsc @liguopku Allow dynamic component read numpy matrix as feature matrix. Each row corresponding to all feature values of a day, i.e., the dimension of the numpy matrix must be a n x d, where n is the number of dates and d is the feature dimension.