### PR TITLE
passing printInfo to builder

### DIFF
--- a/pydlm/func/_dlm.py
+++ b/pydlm/func/_dlm.py
@@ -82,6 +82,7 @@ class _dlm(object):
         self.options = self._defaultOptions(**options)
         self.time = None
         self._printInfo = options.get('printInfo', True)
+        self.builder._printInfo = self._printInfo
 
     # an inner class to store all options
     class _defaultOptions(object):


### PR DESCRIPTION
printInfo option from dlm constructor must be passed to builder where it is used to control console output. 