### PR TITLE
filtered observation must be unboxed for completing missing data

### DIFF
--- a/pydlm/func/_dlm.py
+++ b/pydlm/func/_dlm.py
@@ -564,7 +564,7 @@ class _dlm(object):
             result.df[step] = model.df
             # pad missing value with filtered result
             if self.data[step] is None:
-                self.padded_data[step] = result.filteredObs[step]
+                self.padded_data[step] = result.filteredObs[step][0,0]
 
         elif filterType == 'backwardSmoother':
             result.smoothedState[step] = model.state

--- a/pydlm/tests/func/test_dlm.py
+++ b/pydlm/tests/func/test_dlm.py
@@ -31,7 +31,8 @@ class test_dlm(unittest.TestCase):
         self.dlm6.builder + trend(degree=0, discount=0.9, w=1.0) + \
             seasonality(period=2, discount=0.8, w=1.0) + \
             autoReg(degree=3, discount=1.0)
-        self.dlm7.builder + trend(degree=0, discount=1, w=1.0)
+        self.dlm7.builder + trend(degree=0, discount=1, w=1.0) + \
+            autoReg(degree=1)
         self.dlm1._initialize()
         self.dlm2._initialize()
         self.dlm3._initialize()

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
       'matplotlib',
     ],
     tests_require = [
+      'unittest',
     ],
     extras_require = {
         'docs': [

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ setup(
       'matplotlib',
     ],
     tests_require = [
-      'unittest',
     ],
     extras_require = {
         'docs': [


### PR DESCRIPTION
Unless unboxed, a single element matrix is inserted into the data, and autoReg component fails. Unit test modified so that it manifests the error without the change.