### PR TITLE
Updated pydlm for compatibility with python3.10

### DIFF
--- a/pydlm/modeler/dynamic.py
+++ b/pydlm/modeler/dynamic.py
@@ -15,7 +15,7 @@ The name dynamic means that the features are changing over time.
 
 """
 import numpy as np
-from collections import MutableSequence
+from collections.abc import MutableSequence
 from copy import deepcopy
 
 import pydlm.base.tools as tl

--- a/pydlm/plot/dlmPlot.py
+++ b/pydlm/plot/dlmPlot.py
@@ -516,7 +516,7 @@ def subplot(size, location):
     Used for plotting multiple figures
 
     """
-    plt.subplot(str(size[0]) + str(size[1]) + str(location))
+    plt.subplot(int(str(size[0]) + str(size[1]) + str(location)))
 
 
 def plotout():


### PR DESCRIPTION
Updated an import from `collections` so that the package is compatible with `python3.10`. 

```
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
Cell In[2], line 1
----> 1 from pydlm import dlm, trend, seasonality, dynamic, autoReg, longSeason

File ~/repos/oak/.oak/lib/python3.10/site-packages/pydlm/__init__.py:8
      6 from pydlm.modeler.trends import trend
      7 from pydlm.modeler.seasonality import seasonality
----> 8 from pydlm.modeler.dynamic import dynamic
      9 from pydlm.modeler.autoReg import autoReg
     10 from pydlm.modeler.longSeason import longSeason

File ~/repos/oak/.oak/lib/python3.10/site-packages/pydlm/modeler/dynamic.py:18
      1 """
      2 =========================================================================
      3 
   (...)
     15 
     16 """
     17 import numpy as np
---> 18 from collections import MutableSequence
     19 from copy import deepcopy
     21 import pydlm.base.tools as tl

ImportError: cannot import name 'MutableSequence' from 'collections' (/usr/lib/python3.10/collections/__init__.py)
```