### PR TITLE
prepare for release on pypi

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,7 @@ Welcome to [pydlm](https://pydlm.github.io/), a flexible time series modeling li
 
 Updates
 -------------------------------------------
-* Version 0.1.1.12 has been released on PyPI.
-    * Added support and CI for Python 3.8, 3.9, 3.10, 3.11
-    * Migrated CI from Travis to CircleCI
-    * Setup Github workflow to release based on version tag
-* Github dev updates.
+* Version 0.1.1.13 has been released on PyPI.
     * Migrated all the unnecessary `print()` to the default python logging operations, such as `logging.info`, `logging.warning` and `logging.critical`.
     * Users can now set the model logging level to suppress unnecessary information during model run.
     * Example to only print warning information: 


### PR DESCRIPTION
Update the readme to prepare for 0.1.1.13 release.

Minor version update to include the capability for muting logs